### PR TITLE
Update tolinks.snippet.php

### DIFF
--- a/core/components/taglister/elements/snippets/tolinks.snippet.php
+++ b/core/components/taglister/elements/snippets/tolinks.snippet.php
@@ -67,8 +67,10 @@ if (!empty($extraParams)) {
 
 /* iterate */
 $tags = array();
+$i=1;
 foreach ($items as $item) {
     $itemArray = array();
+	$itemArray['itemId'] = $i;
     $itemArray['item'] = trim($item);
     $params = array();
     if (empty($useTagsFurl)) {
@@ -88,6 +90,7 @@ foreach ($items as $item) {
     $itemArray['url'] = str_replace(' ','+',$itemArray['url']);
     $itemArray['cls'] = $cls;
     $tags[] = $tagLister->getChunk($tpl,$itemArray);
+	$i++;
 }
 
 /* output */


### PR DESCRIPTION
Added itemId that can be used when looping tru tags or any other something-seperated list.

We use this snippet not only for tags but also for filter options and other list, and somtime an itemId would be handy.